### PR TITLE
fix memory leak when rerunning encoder map

### DIFF
--- a/encodermap/autoencoder.py
+++ b/encodermap/autoencoder.py
@@ -1,4 +1,5 @@
 import tensorflow as tf
+from tensorflow.python.framework import ops as tf_ops
 import numpy as np
 from .misc import periodic_distance, variable_summaries, add_layer_summaries, distance_cost
 import os
@@ -246,10 +247,13 @@ class Autoencoder:
         :return:
         """
         self.sess.close()
-        tf.reset_default_graph()
+        tf_ops.dismantle_graph(self.graph)
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        
+    def __del__(self):
         self.close()

--- a/encodermap/autoencoder.py
+++ b/encodermap/autoencoder.py
@@ -246,6 +246,7 @@ class Autoencoder:
         :return:
         """
         self.sess.close()
+        tf.reset_default_graph()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
There is a memory leak due to the accumulation of data in the default graph for every encoder map instance run.
This can be removed by resetting the default_graph when the object is destroyed.