### PR TITLE
Omega Dihedrals Number of Atoms Check Updated

### DIFF
--- a/encodermap/moldata.py
+++ b/encodermap/moldata.py
@@ -113,7 +113,7 @@ class MolData:
 
                 omega_atoms = (self.sorted_atoms.select_atoms("resnum {} and (name CA or name C)".format(i)) +
                              self.sorted_atoms.select_atoms("resnum {} and (name N or name CA)".format(i + 1)))
-                if len(psi_atoms) == 4:
+                if len(omega_atoms) == 4:
                     dihedral_atoms.append(omega_atoms.dihedral)
 
             dihedrals = Dihedral(dihedral_atoms, verbose=True).run(start=start, stop=stop, step=step)


### PR DESCRIPTION
Hey, 

I hope it’s okay to open a PR for this given how small this is. I noticed this (the length sanity check prior to adding omega dihedrals to "dihedral_atoms" was for psi atoms and not omega dihedrals) whilst I was trying to figure out an issue I was having running simulations on my own dataset (I will open a separate issue for that shortly).

Thanks!